### PR TITLE
[CHANGE] Fix the `PatchHook` signature and make it generic w.r.t. to the patched function's type

### DIFF
--- a/api-extractor.json
+++ b/api-extractor.json
@@ -26,6 +26,11 @@
 			"ae-wrong-input-file-type": {
 				"logLevel": "none"
 			}
+		},
+		"tsdocMessageReporting": {
+			"tsdoc-undefined-tag": {
+				"logLevel": "none"
+			}
 		}
 	}
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,6 +1,10 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-type FuncType = (...args: never[]) => unknown;
+/**
+ * A type signifying any unknown function.
+ * @public
+ */
+export type AnyFunction = (...args: any) => any;
 
 /**
  * This is how hook from mod looks like.
@@ -12,10 +16,10 @@ type FuncType = (...args: never[]) => unknown;
  * The return value is then used as return value instead of original one.
  * @public
  */
-export type PatchHook<T extends FuncType = any> = (
-	args: Parameters<T>,
-	next: (args: Parameters<T>) => ReturnType<T>,
-) => ReturnType<T>;
+export type PatchHook<TFunction extends AnyFunction = AnyFunction> = (
+	args: [...Parameters<TFunction>],
+	next: (args: [...Parameters<TFunction>]) => ReturnType<TFunction>,
+) => ReturnType<TFunction>;
 
 /** @public */
 export interface ModSDKModAPI {
@@ -24,13 +28,13 @@ export interface ModSDKModAPI {
 
 	/**
 	 * Hook a BC function
-	 * @template T - The type of hooked function, _e.g._ `typeof CharacterRefresh`
+	 * @template TFunction - The type of hooked function, _e.g._ `typeof CharacterRefresh`
 	 * @param functionName - Name of function to hook. Can contain dots to change methods in objects (e.g. `Player.CanChange`)
 	 * @param priority - Number used to determinate order hooks will be called in. Higher number is called first
 	 * @param hook - The hook itself to use, @see PatchHook
 	 * @returns Function that can be called to remove this hook
 	 */
-	hookFunction<T extends FuncType = any>(functionName: string, priority: number, hook: PatchHook<T>): () => void;
+	hookFunction<TFunction extends AnyFunction = AnyFunction>(functionName: string, priority: number, hook: PatchHook<TFunction>): () => void;
 
 	/**
 	 * Call original function, bypassing any hooks and ignoring any patches applied by ALL mods.

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-type FuncType = (...args: any[]) => any;
+type FuncType = (...args: never[]) => unknown;
 
 /**
  * This is how hook from mod looks like.

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,5 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+type FuncType = (...args: any[]) => any;
+
 /**
  * This is how hook from mod looks like.
  *
@@ -10,21 +12,25 @@
  * The return value is then used as return value instead of original one.
  * @public
  */
-export type PatchHook<Unknown = any> = (args: Unknown[], next: (args: any[]) => Unknown) => any;
+export type PatchHook<T extends FuncType = any> = (
+	args: Parameters<T>,
+	next: (args: Parameters<T>) => ReturnType<T>,
+) => ReturnType<T>;
 
 /** @public */
-export interface ModSDKModAPI<Unknown = any> {
+export interface ModSDKModAPI {
 	/** Unload this mod, removing any hooks or patches by it. To continue using SDK another call to `registerMod` is required */
 	unload(): void;
 
 	/**
 	 * Hook a BC function
+	 * @template T - The type of hooked function, _e.g._ `typeof CharacterRefresh`
 	 * @param functionName - Name of function to hook. Can contain dots to change methods in objects (e.g. `Player.CanChange`)
 	 * @param priority - Number used to determinate order hooks will be called in. Higher number is called first
 	 * @param hook - The hook itself to use, @see PatchHook
 	 * @returns Function that can be called to remove this hook
 	 */
-	hookFunction(functionName: string, priority: number, hook: PatchHook<Unknown>): () => void;
+	hookFunction<T extends FuncType = any>(functionName: string, priority: number, hook: PatchHook<T>): () => void;
 
 	/**
 	 * Call original function, bypassing any hooks and ignoring any patches applied by ALL mods.
@@ -133,7 +139,7 @@ export interface ModSDKModOptions {
  * Accessible using the exported value or as `window.bcModSdk`
  * @public
  */
-export interface ModSDKGlobalAPI<Unknown = any> {
+export interface ModSDKGlobalAPI {
 	/** The version of the SDK itself. Attempting to load two different SDK versions will warn, but work as long as `apiVersion` is same. */
 	readonly version: string;
 	/** The API version of the SDK itself. Attempting to load two different SDK versions will fail. */
@@ -146,12 +152,12 @@ export interface ModSDKGlobalAPI<Unknown = any> {
 	 * @returns The API usable by mod. @see ModSDKModAPI
 	 * @see ModSDKModInfo
 	 */
-	registerMod(info: ModSDKModInfo, options?: ModSDKModOptions): ModSDKModAPI<Unknown>;
+	registerMod(info: ModSDKModInfo, options?: ModSDKModOptions): ModSDKModAPI;
 
 	/**
 	 * @deprecated This way to register mod is deprecated in favour of passing object info, which is more future-proof
 	 */
-	registerMod(name: string, version: string, allowReplace?: boolean): ModSDKModAPI<Unknown>;
+	registerMod(name: string, version: string, allowReplace?: boolean): ModSDKModAPI;
 
 	/** Get info about all registered mods */
 	getModsInfo(): ModSDKModInfo[];

--- a/src/modRegistry.ts
+++ b/src/modRegistry.ts
@@ -1,9 +1,7 @@
-import type { ModSDKModAPI, ModSDKModInfo, ModSDKModOptions, PatchHook } from './api';
+import type { AnyFunction, ModSDKModAPI, ModSDKModInfo, ModSDKModOptions, PatchHook } from './api';
 import { ThrowError } from './errors';
 import { CallOriginal, GetOriginalHash, IHookData, UpdateAllPatches } from './patching';
 import { IsObject } from './utils';
-
-type FuncType = (...args: never[]) => unknown;
 
 interface IModPatchesDefinition {
 	hooks: IHookData[];
@@ -104,8 +102,7 @@ export function RegisterMod(info: ModSDKModInfo | string, options?: ModSDKModOpt
 
 	const api: ModSDKModAPI = {
 		unload: () => UnloadMod(newInfo),
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		hookFunction: <T extends FuncType = any>(functionName: string, priority: number, hook: PatchHook<T>): (() => void) => {
+		hookFunction: <T extends AnyFunction>(functionName: string, priority: number, hook: PatchHook<T>): (() => void) => {
 			if (!newInfo.loaded) {
 				ThrowError(`Mod ${descriptor} attempted to call SDK function after being unloaded`);
 			}

--- a/src/modRegistry.ts
+++ b/src/modRegistry.ts
@@ -3,6 +3,8 @@ import { ThrowError } from './errors';
 import { CallOriginal, GetOriginalHash, IHookData, UpdateAllPatches } from './patching';
 import { IsObject } from './utils';
 
+type FuncType = (...args: any[]) => any;
+
 interface IModPatchesDefinition {
 	hooks: IHookData[];
 	patches: Map<string, string>;
@@ -102,7 +104,7 @@ export function RegisterMod(info: ModSDKModInfo | string, options?: ModSDKModOpt
 
 	const api: ModSDKModAPI = {
 		unload: () => UnloadMod(newInfo),
-		hookFunction: (functionName: string, priority: number, hook: PatchHook): (() => void) => {
+		hookFunction: <T extends FuncType = any>(functionName: string, priority: number, hook: PatchHook<T>): (() => void) => {
 			if (!newInfo.loaded) {
 				ThrowError(`Mod ${descriptor} attempted to call SDK function after being unloaded`);
 			}

--- a/src/modRegistry.ts
+++ b/src/modRegistry.ts
@@ -3,7 +3,7 @@ import { ThrowError } from './errors';
 import { CallOriginal, GetOriginalHash, IHookData, UpdateAllPatches } from './patching';
 import { IsObject } from './utils';
 
-type FuncType = (...args: any[]) => any;
+type FuncType = (...args: never[]) => unknown;
 
 interface IModPatchesDefinition {
 	hooks: IHookData[];
@@ -104,6 +104,7 @@ export function RegisterMod(info: ModSDKModInfo | string, options?: ModSDKModOpt
 
 	const api: ModSDKModAPI = {
 		unload: () => UnloadMod(newInfo),
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		hookFunction: <T extends FuncType = any>(functionName: string, priority: number, hook: PatchHook<T>): (() => void) => {
 			if (!newInfo.loaded) {
 				ThrowError(`Mod ${descriptor} attempted to call SDK function after being unloaded`);


### PR DESCRIPTION
* Fixes the `Unknown` generic parameter. A problem with the old usage of `Unknown[]` was that it demands a homogeneous list, rejecting tuple-esque types such as `Parameters<CharacterRefresh>`.
* Change the generic parameter to the type of the patched functions. This allows for easy reuse of the patched function's signature (see example below), including access to its exact parameter- and return-type
* Make the `hookFunction` function generic rather than the entire underlying interface. This makes more sense (and is more convenient...) as the type of hooked function generally varies with each call, and having the generic parameter on the interface effectively locks it in upon its definition.

All in all this means that examples such as these will now typecheck:
```ts
const sdk: ModSDKModAPI;

sdk.hookFunction<typeof CharacterRefresh>("CharacterRefresh", 0, (args, next) => {
  return next(args);
});
```