### PR TITLE
Version 1.2.0

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,6 +17,6 @@
 	"typescript.format.semicolons": "insert",
 	"typescript.preferences.quoteStyle": "single",
 	"editor.codeActionsOnSave": {
-		"source.fixAll.eslint": true
+		"source.fixAll.eslint": "explicit"
 	}
 }

--- a/api-extractor.json
+++ b/api-extractor.json
@@ -26,6 +26,11 @@
 			"ae-wrong-input-file-type": {
 				"logLevel": "none"
 			}
+		},
+		"tsdocMessageReporting": {
+			"tsdoc-undefined-tag": {
+				"logLevel": "none"
+			}
 		}
 	}
 }

--- a/api-extractor.json
+++ b/api-extractor.json
@@ -30,6 +30,9 @@
 		"tsdocMessageReporting": {
 			"tsdoc-undefined-tag": {
 				"logLevel": "none"
+			},
+			"tsdoc-unsupported-tag": {
+				"logLevel": "none"
 			}
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "bondage-club-mod-sdk",
-	"version": "1.1.0",
+	"version": "1.2.0",
 	"repository": "git@github.com:Jomshir98/bondage-club-mod-sdk.git",
 	"author": "Jomshir98 <jomshir98@protonmail.com>",
 	"license": "MIT",

--- a/src/api.ts
+++ b/src/api.ts
@@ -166,6 +166,7 @@ export interface ModSDKGlobalAPI {
 
 	/** Internal API, please **DO NOT USE** */
 	readonly errorReporterHooks: {
+		apiEndpointEnter: ((fn: string, mod: string) => (() => void)) | null;
 		hookEnter: ((fn: string, mod: string) => (() => void)) | null;
 		hookChainExit: ((fn: string, patchMods: ReadonlySet<string>) => (() => void)) | null;
 	};

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,6 +1,12 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 /**
+ * A type signifying any unknown function.
+ * @public
+ */
+export type AnyFunction = (...args: any) => any;
+
+/**
  * This is how hook from mod looks like.
  *
  * As first argument it receives all arguments the original function received.
@@ -10,21 +16,25 @@
  * The return value is then used as return value instead of original one.
  * @public
  */
-export type PatchHook<Unknown = any> = (args: Unknown[], next: (args: any[]) => Unknown) => any;
+export type PatchHook<TFunction extends AnyFunction = AnyFunction> = (
+	args: [...Parameters<TFunction>],
+	next: (args: [...Parameters<TFunction>]) => ReturnType<TFunction>,
+) => ReturnType<TFunction>;
 
 /** @public */
-export interface ModSDKModAPI<Unknown = any> {
+export interface ModSDKModAPI {
 	/** Unload this mod, removing any hooks or patches by it. To continue using SDK another call to `registerMod` is required */
 	unload(): void;
 
 	/**
 	 * Hook a BC function
+	 * @template TFunction - The type of hooked function, _e.g._ `typeof CharacterRefresh`
 	 * @param functionName - Name of function to hook. Can contain dots to change methods in objects (e.g. `Player.CanChange`)
 	 * @param priority - Number used to determinate order hooks will be called in. Higher number is called first
 	 * @param hook - The hook itself to use, @see PatchHook
 	 * @returns Function that can be called to remove this hook
 	 */
-	hookFunction(functionName: string, priority: number, hook: PatchHook<Unknown>): () => void;
+	hookFunction<TFunction extends AnyFunction = AnyFunction>(functionName: string, priority: number, hook: PatchHook<TFunction>): () => void;
 
 	/**
 	 * Call original function, bypassing any hooks and ignoring any patches applied by ALL mods.
@@ -133,7 +143,7 @@ export interface ModSDKModOptions {
  * Accessible using the exported value or as `window.bcModSdk`
  * @public
  */
-export interface ModSDKGlobalAPI<Unknown = any> {
+export interface ModSDKGlobalAPI {
 	/** The version of the SDK itself. Attempting to load two different SDK versions will warn, but work as long as `apiVersion` is same. */
 	readonly version: string;
 	/** The API version of the SDK itself. Attempting to load two different SDK versions will fail. */
@@ -146,12 +156,12 @@ export interface ModSDKGlobalAPI<Unknown = any> {
 	 * @returns The API usable by mod. @see ModSDKModAPI
 	 * @see ModSDKModInfo
 	 */
-	registerMod(info: ModSDKModInfo, options?: ModSDKModOptions): ModSDKModAPI<Unknown>;
+	registerMod(info: ModSDKModInfo, options?: ModSDKModOptions): ModSDKModAPI;
 
 	/**
 	 * @deprecated This way to register mod is deprecated in favour of passing object info, which is more future-proof
 	 */
-	registerMod(name: string, version: string, allowReplace?: boolean): ModSDKModAPI<Unknown>;
+	registerMod(name: string, version: string, allowReplace?: boolean): ModSDKModAPI;
 
 	/** Get info about all registered mods */
 	getModsInfo(): ModSDKModInfo[];

--- a/src/api.ts
+++ b/src/api.ts
@@ -158,11 +158,6 @@ export interface ModSDKGlobalAPI {
 	 */
 	registerMod(info: ModSDKModInfo, options?: ModSDKModOptions): ModSDKModAPI;
 
-	/**
-	 * @deprecated This way to register mod is deprecated in favour of passing object info, which is more future-proof
-	 */
-	registerMod(name: string, version: string, allowReplace?: boolean): ModSDKModAPI;
-
 	/** Get info about all registered mods */
 	getModsInfo(): ModSDKModInfo[];
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { ThrowError } from './errors';
-import type { ModSDKGlobalAPI, ModSDKModAPI, ModSDKModInfo, ModSDKModOptions } from './api';
+import type { ModSDKGlobalAPI } from './api';
 import { API_VERSION, CreateGlobalAPI } from './sdkApi';
 import { IsObject } from './utils';
 
@@ -18,21 +18,6 @@ function Init(): ModSDKGlobalAPI {
 			`Mod SDK warning: Loading different but compatible versions ('${VERSION}' vs '${window.bcModSdk.version}')\n` +
 			'One of mods you are using is using an old version of SDK. It will work for now but please inform author to update',
 		);
-		// Shim to support new registration way with old api
-		if (window.bcModSdk.version.startsWith('1.0.') && typeof (window.bcModSdk as (ModSDKGlobalAPI & { _shim10register?: true; }))._shim10register === 'undefined') {
-			const oldAPI = window.bcModSdk;
-			const shimmedAPI: ModSDKGlobalAPI & { _shim10register: true; } = Object.freeze({
-				...oldAPI,
-				registerMod: (info: ModSDKModInfo | string, options?: ModSDKModOptions | string, oldAllowReplace?: boolean): ModSDKModAPI => {
-					if (info && typeof info === 'object' && typeof info.name === 'string' && typeof info.version === 'string')
-						return oldAPI.registerMod(info.name, info.version, typeof options === 'object' && !!options && options.allowReplace === true);
-					// @ts-expect-error: Passing known possibly wrong data
-					return oldAPI.registerMod(info, options, oldAllowReplace);
-				},
-				_shim10register: true,
-			});
-			window.bcModSdk = shimmedAPI;
-		}
 	}
 	// Otherwise this exact version of Mod SDK is already loaded, so do nothing
 	return window.bcModSdk;

--- a/src/modRegistry.ts
+++ b/src/modRegistry.ts
@@ -31,21 +31,7 @@ export function UnloadMod(mod: ModInfo): void {
 	UpdateAllPatches();
 }
 
-export function RegisterMod(info: ModSDKModInfo | string, options?: ModSDKModOptions | string, oldAllowReplace?: boolean): ModSDKModAPI {
-	if (typeof info === 'string' && typeof options === 'string') {
-		alert(
-			`Mod SDK warning: Mod '${info}' is registering in a deprecated way.\n` +
-			'It will work for now, but please inform author to update.',
-		);
-		info = {
-			name: info,
-			fullName: info,
-			version: options,
-		};
-		options = {
-			allowReplace: oldAllowReplace === true,
-		};
-	}
+export function RegisterMod(info: ModSDKModInfo, options?: ModSDKModOptions): ModSDKModAPI {
 	if (!info || typeof info !== 'object') {
 		ThrowError(`Failed to register mod: Expected info object, got ${typeof info}`);
 	}

--- a/src/modRegistry.ts
+++ b/src/modRegistry.ts
@@ -1,4 +1,4 @@
-import type { ModSDKModAPI, ModSDKModInfo, ModSDKModOptions, PatchHook } from './api';
+import type { AnyFunction, ModSDKModAPI, ModSDKModInfo, ModSDKModOptions, PatchHook } from './api';
 import { ThrowError } from './errors';
 import { CallOriginal, GetOriginalHash, IHookData, UpdateAllPatches } from './patching';
 import { IsObject } from './utils';
@@ -102,7 +102,7 @@ export function RegisterMod(info: ModSDKModInfo | string, options?: ModSDKModOpt
 
 	const api: ModSDKModAPI = {
 		unload: () => UnloadMod(newInfo),
-		hookFunction: (functionName: string, priority: number, hook: PatchHook): (() => void) => {
+		hookFunction: <T extends AnyFunction>(functionName: string, priority: number, hook: PatchHook<T>): (() => void) => {
 			if (!newInfo.loaded) {
 				ThrowError(`Mod ${descriptor} attempted to call SDK function after being unloaded`);
 			}

--- a/src/patching.ts
+++ b/src/patching.ts
@@ -20,13 +20,13 @@ interface IPatchedFunctionPrecomputed {
 	readonly final: (...args: any[]) => any;
 }
 
-interface IPatchedFunctionDataBase {
+export interface IPatchedFunctionDataBase {
 	readonly name: string;
 	readonly original: (...args: any[]) => any;
 	readonly originalHash: string;
 }
 
-interface IPatchedFunctionData extends IPatchedFunctionDataBase {
+export interface IPatchedFunctionData extends IPatchedFunctionDataBase {
 	precomputed: IPatchedFunctionPrecomputed;
 	readonly context: Record<string, any>;
 	readonly contextProperty: string;
@@ -125,7 +125,7 @@ function UpdatePatchedFunction(data: IPatchedFunctionDataBase): IPatchedFunction
 	};
 }
 
-function InitPatchableFunction(target: string, forceUpdate: boolean = false): IPatchedFunctionData {
+export function InitPatchableFunction(target: string, forceUpdate: boolean = false): IPatchedFunctionData {
 	let result = patchedFunctions.get(target);
 	if (!result) {
 		let context: Record<string, any> = window as any;
@@ -167,26 +167,9 @@ function InitPatchableFunction(target: string, forceUpdate: boolean = false): IP
 }
 
 export function UpdateAllPatches(): void {
-	const functions: Set<string> = new Set();
-
-	for (const mod of registeredMods.values()) {
-		for (const functionName of mod.patching.keys()) {
-			functions.add(functionName);
-		}
+	for (const patchInfo of patchedFunctions.values()) {
+		patchInfo.precomputed = UpdatePatchedFunction(patchInfo);
 	}
-
-	for (const functionName of patchedFunctions.keys()) {
-		functions.add(functionName);
-	}
-
-	for (const functionName of functions) {
-		InitPatchableFunction(functionName, true);
-	}
-}
-
-export function CallOriginal(target: string, args: any[], context: any = window): any {
-	const data = InitPatchableFunction(target);
-	return data.original.apply(context, args);
 }
 
 export function GetPatchedFunctionsInfo(): Map<string, PatchedFunctionInfo> {
@@ -203,8 +186,4 @@ export function GetPatchedFunctionsInfo(): Map<string, PatchedFunctionInfo> {
 		});
 	}
 	return result;
-}
-
-export function GetOriginalHash(target: string): string {
-	return InitPatchableFunction(target).originalHash;
 }

--- a/src/sdkApi.ts
+++ b/src/sdkApi.ts
@@ -13,6 +13,7 @@ export function CreateGlobalAPI(): ModSDKGlobalAPI {
 		getModsInfo: GetModsInfo,
 		getPatchingInfo: GetPatchedFunctionsInfo,
 		errorReporterHooks: Object.seal({
+			apiEndpointEnter: null,
 			hookEnter: null,
 			hookChainExit: null,
 		}),


### PR DESCRIPTION
This release brings several changes and fixes to the ModSDK:
- Changed the type signature of `hookFunction`, `patchFunction`, and `callOriginal` methods to work out-of-the-box with Rama's [BC-stubs](https://github.com/bananarama92/BC-stubs) for function types (or any other way you are using for injecting global BC types)
- Fixed that trying to hook a non-existent method will cause any future hook/patch to crash as well, no matter what mod is it from
- Added a new error reporting helper for detecting which mod is responsible for trying to hook non-existent method
- Some internal cleanup and removal of old code